### PR TITLE
Fix an issue with wrong conversion of addresses in LockPaymentCondition

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
         cd tools
         export KEEPER_OWNER_ROLE_ADDRESS="0xe2DD09d719Da89e5a3D0F2549c7E24566e947260"
         rm -rf "${HOME}/.nevermined/nevermined-contracts/artifacts"
-        ./start_nevermined.sh --latest --no-marketplace --no-gateway --no-metadata --no-graph ${{ matrix.network }} &
+        ./start_nevermined.sh --latest --no-marketplace --no-graph ${{ matrix.network }} &
         cd ..
         ./scripts/wait-nevermined.sh
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nevermined-io/subgraphs",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "Nevermined subgraph graphql clients",
   "main": "./build/index.js",
   "typings": "./build/index.d.ts",

--- a/src/LockPaymentCondition.ts
+++ b/src/LockPaymentCondition.ts
@@ -117,7 +117,7 @@ export const getFulfilledById = async function <K extends keyof FulfilledResult>
     if (obj["_receivers"])
         formattedObj["_receivers"] = obj["_receivers"];
     if (obj["_amounts"])
-        formattedObj["_amounts"] = wei(obj["_amounts"], 0);
+        formattedObj["_amounts"] = obj["_amounts"].map(a => wei(a, 0));
     return formattedObj as Pick<FulfilledResult, K>;
 };
 export const getFulfilleds = async function <K extends keyof FulfilledResult>(url: string, options: MultiQueryOptions<FulfilledFilter, FulfilledResult>, args: FulfilledArgs<K>): Promise<Pick<FulfilledResult, K>[]> {
@@ -160,7 +160,7 @@ export const getFulfilleds = async function <K extends keyof FulfilledResult>(ur
             if (obj["_receivers"])
                 formattedObj["_receivers"] = obj["_receivers"];
             if (obj["_amounts"])
-                formattedObj["_amounts"] = wei(obj["_amounts"], 0);
+                formattedObj["_amounts"] = obj["_amounts"].map(a => wei(a, 0));
             return formattedObj as Pick<FulfilledResult, K>;
         });
         results = results.concat(newResults);

--- a/subgraphs/LockPaymentCondition/generated/schema.ts
+++ b/subgraphs/LockPaymentCondition/generated/schema.ts
@@ -8,7 +8,8 @@ import {
   store,
   Bytes,
   BigInt,
-  BigDecimal
+  BigDecimal,
+  Address
 } from "@graphprotocol/graph-ts";
 
 export class Fulfilled extends Entity {
@@ -96,13 +97,13 @@ export class Fulfilled extends Entity {
     this.set("_tokenAddress", Value.fromBytes(value));
   }
 
-  get _receivers(): Array<Bytes> {
+  get _receivers(): Array<Address> {
     let value = this.get("_receivers");
-    return value!.toBytesArray();
+    return value!.toAddressArray();
   }
 
-  set _receivers(value: Array<Bytes>) {
-    this.set("_receivers", Value.fromBytesArray(value));
+  set _receivers(value: Array<Address>) {
+    this.set("_receivers", Value.fromAddressArray(value));
   }
 
   get _amounts(): Array<BigInt> {

--- a/subgraphs/LockPaymentCondition/src/mapping.ts
+++ b/subgraphs/LockPaymentCondition/src/mapping.ts
@@ -1,4 +1,4 @@
-import { ethereum } from '@graphprotocol/graph-ts'
+import { ethereum, Bytes, log } from '@graphprotocol/graph-ts'
 import {
   Fulfilled as FulfilledEvent,
   OwnershipTransferred as OwnershipTransferredEvent,
@@ -23,7 +23,7 @@ export function handleFulfilled(event: FulfilledEvent): void {
   entity._conditionId = event.params._conditionId
   entity._rewardAddress = event.params._rewardAddress
   entity._tokenAddress = event.params._tokenAddress
-  entity._receivers = ethereum.Value.fromAddressArray(event.params._receivers).toBytesArray()
+  entity._receivers = event.params._receivers
   entity._amounts = event.params._amounts
   entity.save()
 }

--- a/test/LockPaymentCondition.test.ts
+++ b/test/LockPaymentCondition.test.ts
@@ -1,0 +1,125 @@
+import { assert } from 'chai'
+import { ApolloClient, InMemoryCache, gql, NormalizedCacheObject } from '@apollo/client/core'
+import { WebSocketLink } from '@apollo/client/link/ws'
+import { SubscriptionClient } from 'subscriptions-transport-ws'
+import ws from 'ws'
+
+import { Account, DDO, MetaData, Nevermined} from '@nevermined-io/nevermined-sdk-js'
+import { didZeroX, zeroX } from '@nevermined-io/nevermined-sdk-js/dist/node/utils'
+
+import { config } from './config'
+import { getFulfilleds } from '../src/LockPaymentCondition'
+import { getMetadata } from './utils'
+import AssetRewards from '@nevermined-io/nevermined-sdk-js/dist/node/models/AssetRewards'
+
+
+let nevermined: Nevermined
+let publisher: Account
+let consumer: Account
+let wsClient: ApolloClient<NormalizedCacheObject>
+let metadata: MetaData
+let ddo: DDO
+let agreementId: string
+
+describe('LockPaymentCondition', () => {
+    before(async () => {
+        nevermined = await Nevermined.getInstance(config)
+        ;[publisher, consumer] = await nevermined.accounts.list()
+
+        metadata = getMetadata()
+
+        const subscriptionClient = new SubscriptionClient(
+            'ws://localhost:9001/subgraphs/name/neverminedio/LockPaymentCondition',
+            {
+                reconnect: true,
+            },
+            ws,
+
+        )
+        const webSocketLink = new WebSocketLink(subscriptionClient)
+        wsClient = new ApolloClient({
+            link: webSocketLink,
+            cache: new InMemoryCache(),
+        })
+    })
+
+    it('should register an NFT', async () => {
+        ddo = await nevermined.nfts.create(
+            metadata,
+            publisher,
+            10,
+            0,
+            new AssetRewards(new Map([
+                [publisher.getId(), 10],
+                [consumer.getId(), 10],
+            ]))
+        )
+        assert.isDefined(ddo)
+        await nevermined.nfts.mint(ddo.id, 1, publisher)
+    })
+
+    it('should order an NFT', async () =>{
+        await consumer.requestTokens(100)
+        agreementId = await nevermined.nfts.order(ddo.id, 1, consumer)
+        assert.isDefined(agreementId)
+    })
+
+    it('should subscribe and wait for LockPaymentCondition', async () => {
+        const query = `
+                subscription($agreementId: Bytes) {
+                    fulfilleds(where: {_agreementId: $agreementId}) {
+                        _did,
+                        _agreementId,
+                    }
+                }
+            `
+            const observable = wsClient.subscribe({
+                query: gql(query),
+                variables: {
+                    agreementId: zeroX(agreementId),
+                },
+            })
+
+            const promise = new Promise((resolve, reject) => {
+                observable.subscribe(
+                    x => {
+                        if (x.data.fulfilleds !== null && x.data.fulfilleds.length > 0) {
+                            resolve(x)
+                        }
+                    },
+                    err => reject(err),
+                )
+            })
+            const result: any = await promise
+            const event = result.data.fulfilleds[0]
+            assert.equal(event._did, didZeroX(ddo.id))
+            assert.equal(event._agreementId, agreementId)
+    })
+
+    it('should query the LockPaymentCondition Fulfilled event', async () => {
+        const response = await getFulfilleds(
+            'http://localhost:9000/subgraphs/name/neverminedio/LockPaymentCondition',
+            {
+                where: {
+                    _agreementId: zeroX(agreementId),
+                },
+
+            },
+            {
+                _agreementId: true,
+                _did: true,
+                _conditionId: true,
+                _rewardAddress: true,
+                _tokenAddress: true,
+                _receivers: true,
+                _amounts: true,
+            },
+        )
+        const event = response.pop()
+        assert.isDefined(event)
+        assert.equal(event._agreementId, agreementId)
+        assert.equal(event._did, didZeroX(ddo.id))
+        assert.equal(event._receivers[0], [publisher.getId().toLowerCase()][0])
+        assert.deepEqual(event._amounts.map(a => a.toNumber()), [10, 10])
+    })
+})

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,0 +1,68 @@
+import { MetaData } from "@nevermined-io/nevermined-sdk-js"
+
+const metadata: Partial<MetaData> = {
+    main: {
+        name: undefined,
+        type: 'dataset',
+        dateCreated: '2012-10-10T17:00:00Z',
+        datePublished: '2012-10-10T17:00:00Z',
+        author: 'Met Office',
+        license: 'CC-BY',
+        price: '21' + '0'.repeat(18),
+        files: [
+            {
+                index: 0,
+                contentType: 'application/json',
+                url:
+                    'https://github.com/nevermined-io/docs/blob/master/docs/architecture/specs/metadata/examples/ddo-example.json'
+            },
+            {
+                index: 1,
+                contentType: 'text/plain',
+                url: 'https://github.com/nevermined-io/docs/blob/master/README.md'
+            }
+        ]
+    },
+    additionalInformation: {
+        description: 'Weather information of UK including temperature and humidity',
+        copyrightHolder: 'Met Office',
+        workExample: '423432fsd,51.509865,-0.118092,2011-01-01T10:55:11+00:00,7.2,68',
+        links: [
+            {
+                name: 'Sample of Asset Data',
+                type: 'sample',
+                url: 'https://foo.com/sample.csv'
+            },
+            {
+                name: 'Data Format Definition',
+                type: 'format',
+                url: 'https://foo.com/sample.csv'
+            }
+        ],
+        inLanguage: 'en',
+        categories: ['Economy', 'Data Science'],
+        tags: ['weather', 'uk', '2011', 'temperature', 'humidity']
+    }
+}
+
+export const generateMetadata = (
+    name: string,
+    price?: number,
+    nonce: string | number = Math.random()
+): Partial<MetaData> => ({
+    ...metadata,
+    main: {
+        ...metadata.main,
+        name: name,
+        price: (price || 21) + '0'.repeat(18),
+        ...({ nonce } as any)
+    },
+    additionalInformation: {
+        ...metadata.additionalInformation
+    }
+})
+
+export const getMetadata = (
+    price?: number,
+    nonce: string | number = Math.random()
+): MetaData => generateMetadata('TestAsset', price, nonce) as MetaData


### PR DESCRIPTION
## Description

- bumped version to v0.2.8
- fixed and issue with the conversion of the amounts in the
  lockPaymentCondition subgraph client

## Is this PR related with an open issue?

Related to Issue #

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Checklist:

- [ ] Follows the code style of this project.
- [x] Tests Cover Changes
- [ ] Documentation

#### Funny gif

![Put a link of a funny gif inside the parenthesis-->](https://i.pinimg.com/originals/68/fa/39/68fa39b267c372249ae78893d41e27b7.gif)