### PR TITLE
Remove hard-coded spree network from entrypoint.sh

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -21,7 +21,7 @@ VERSION=$(echo ${VERSION%%.*} | tr -d '"')
 yarn nevermined:update-addresses $KEEPER_NETWORK_NAME
 OVERRIDE_SUBGRAPH_STARTING_BLOCK=10 yarn nevermined:update-startblock $KEEPER_NETWORK_NAME
 # we always use spree in the subgraph manifest for local development networks
-yarn nevermined:update-network spree
+yarn nevermined:update-network $KEEPER_NETWORK_NAME $VERSION
 yarn nevermined:create development $KEEPER_NETWORK_NAME $VERSION
 yarn nevermined:deploy development $KEEPER_NETWORK_NAME $VERSION
 


### PR DESCRIPTION
## Description

Remove hard-coded spree network from entrypoint.sh when running the `update network` script

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Checklist:

- [X] Follows the code style of this project.
- [ ] Tests Cover Changes
- [ ] Documentation

#### Funny gif

![Put a link of a funny gif inside the parenthesis-->]()